### PR TITLE
add info for Wasabi 1.1.12.2

### DIFF
--- a/db/wallets/wasabi.json
+++ b/db/wallets/wasabi.json
@@ -1,26 +1,56 @@
 {
     "name": "Wasabi",
     "comment": "Wasabi does not publish a SHA256 on https://github.com/zkSNACKs/WalletWasabi/releases/",
-    "versions":[
-    {
-        "version_number": "1.1.12",
-        "arch": "x86_64-linux-gnu, deb",
-        "sources": ["https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.12/Wasabi-1.1.12.deb"],
-        "sha256": "62b096b60d9fadd7a62cc26544e024864cdbcddc23ec8292e28e29e62f5c8fbb",
-        "signed_by": "6FB3872B5D42292F59920797856348328949861E",
-        "signature_url": "https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.12/Wasabi-1.1.12.deb.asc"
-    },
-    {
-        "version_number": "1.1.12",
-        "arch": "osx",
-        "sources": ["https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.12/Wasabi-1.1.12.dmg"],
-        "sha256": "38f6c55e928494d669b1e5def5470c2c701ca16900e19e763b5f7aa9673485a6"
-    },
-    {
-        "version_number": "1.1.12",
-        "arch": "Windows, MSI",
-        "sources": ["https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.12/Wasabi-1.1.12.msi"],
-        "sha256": "9aef2cf3f76a479c3d0425fc4e5a42b2cfb30406b1d62ff8cc60e602c4f97e39"
-    }
+    "versions": [
+        {
+            "version_number": "1.1.12",
+            "arch": "x86_64-linux-gnu, deb",
+            "sources": [
+                "https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.12/Wasabi-1.1.12.deb"
+            ],
+            "sha256": "62b096b60d9fadd7a62cc26544e024864cdbcddc23ec8292e28e29e62f5c8fbb",
+            "signed_by": "6FB3872B5D42292F59920797856348328949861E",
+            "signature_url": "https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.12/Wasabi-1.1.12.deb.asc"
+        },
+        {
+            "version_number": "1.1.12",
+            "arch": "osx",
+            "sources": [
+                "https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.12/Wasabi-1.1.12.dmg"
+            ],
+            "sha256": "38f6c55e928494d669b1e5def5470c2c701ca16900e19e763b5f7aa9673485a6"
+        },
+        {
+            "version_number": "1.1.12",
+            "arch": "Windows, MSI",
+            "sources": [
+                "https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.12/Wasabi-1.1.12.msi"
+            ],
+            "sha256": "9aef2cf3f76a479c3d0425fc4e5a42b2cfb30406b1d62ff8cc60e602c4f97e39"
+        },
+        {
+            "version_number": "1.1.12.2",
+            "arch": "",
+            "sources": [
+                "https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.12.2/Wasabi-1.1.12.2.deb"
+            ],
+            "sha256": "df2c619a921142ec93ee0b224a59ccfe0c06f46131942a2add07870b99aa430d"
+        },
+        {
+            "version_number": "1.1.12.2",
+            "arch": "",
+            "sources": [
+                "https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.12.2/Wasabi-1.1.12.2.dmg"
+            ],
+            "sha256": "8e69d483b1dd5a864c19a84efe5fde8589b9375e6f5c8fc7c47b0b23e34a51e6"
+        },
+        {
+            "version_number": "1.1.12.2",
+            "arch": "",
+            "sources": [
+                "https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.12.2/Wasabi-1.1.12.2.msi"
+            ],
+            "sha256": "121115ca087b95b5431d5d9c162bfc1a47f6d497e0ac622a121056c3a50c99a5"
+        }
     ]
 }

--- a/db/wallets/wasabi.json
+++ b/db/wallets/wasabi.json
@@ -34,7 +34,8 @@
             "sources": [
                 "https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.12.2/Wasabi-1.1.12.2.deb"
             ],
-            "sha256": "df2c619a921142ec93ee0b224a59ccfe0c06f46131942a2add07870b99aa430d"
+            "sha256": "df2c619a921142ec93ee0b224a59ccfe0c06f46131942a2add07870b99aa430d",
+            "signature_url": "https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.12.2/Wasabi-1.1.12.2.deb.asc"
         },
         {
             "version_number": "1.1.12.2",
@@ -42,7 +43,8 @@
             "sources": [
                 "https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.12.2/Wasabi-1.1.12.2.dmg"
             ],
-            "sha256": "8e69d483b1dd5a864c19a84efe5fde8589b9375e6f5c8fc7c47b0b23e34a51e6"
+            "sha256": "8e69d483b1dd5a864c19a84efe5fde8589b9375e6f5c8fc7c47b0b23e34a51e6",
+            "signature_url": "https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.12.2/Wasabi-1.1.12.2.dmg.asc"
         },
         {
             "version_number": "1.1.12.2",
@@ -50,7 +52,8 @@
             "sources": [
                 "https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.12.2/Wasabi-1.1.12.2.msi"
             ],
-            "sha256": "121115ca087b95b5431d5d9c162bfc1a47f6d497e0ac622a121056c3a50c99a5"
+            "sha256": "121115ca087b95b5431d5d9c162bfc1a47f6d497e0ac622a121056c3a50c99a5",
+            "signature_url": "https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.12.2/Wasabi-1.1.12.2.msi.asc"
         }
     ]
 }


### PR DESCRIPTION
Pushed info based on @zkSNACKs' https://github.com/zkSNACKs/WalletWasabi/releases/tag/v1.1.12.2

```
df2c619a921142ec93ee0b224a59ccfe0c06f46131942a2add07870b99aa430d  target/Wasabi-1.1.12.2.deb
8e69d483b1dd5a864c19a84efe5fde8589b9375e6f5c8fc7c47b0b23e34a51e6  target/Wasabi-1.1.12.2.dmg
121115ca087b95b5431d5d9c162bfc1a47f6d497e0ac622a121056c3a50c99a5  target/Wasabi-1.1.12.2.msi
```